### PR TITLE
Fix errors and implement new features

### DIFF
--- a/Component/FirstComponent.mo
+++ b/Component/FirstComponent.mo
@@ -1,9 +1,8 @@
 within TestPackage.Component;
 model FirstComponent "First Component"
   extends
-    TestPackage.Interface.Partial(
-       container=TestPackage.Types.Container.Hand
-    );
+    TestPackage.Interface.PartialComponent(
+       container=TestPackage.Types.Container.Hand);
   parameter String component_param="First Component Param"
     annotation (Evaluate=true, Dialog(group="TestGroup"));
 

--- a/Component/SecondComponent.mo
+++ b/Component/SecondComponent.mo
@@ -1,9 +1,8 @@
 within TestPackage.Component;
 model SecondComponent "Second Component"
   extends
-    TestPackage.Interface.Partial(
-      container=TestPackage.Types.Container.Bowl
-    );
+    TestPackage.Interface.PartialComponent(
+      container=TestPackage.Types.Container.Bowl);
   parameter String component_param="Second Component Param"
     annotation (Evaluate=true, Dialog(group="TestGroup"));
 

--- a/Component/ThirdComponent.mo
+++ b/Component/ThirdComponent.mo
@@ -1,10 +1,17 @@
 within TestPackage.Component;
 model ThirdComponent "Third Component"
   extends
-    TestPackage.Interface.Partial(
-      container=TestPackage.Types.Container.Bowl
-    );
+    TestPackage.Interface.PartialComponent(
+      container=TestPackage.Types.Container.Cone);
+
   parameter String component_param="Third Component Param"
     annotation (Evaluate=true, Dialog(group="TestGroup"));
+
+  /*
+  Test that a subcomponent has access to an outer declaration
+  */
+  outer replaceable TestPackage.Interface.PartialComponent selectable_component;
+
+  parameter TestPackage.Types.Container container_from_outer = selectable_component.container;
 
 end ThirdComponent;

--- a/Component/package.order
+++ b/Component/package.order
@@ -1,0 +1,3 @@
+FirstComponent
+SecondComponent
+ThirdComponent

--- a/Interface/PartialComponent.mo
+++ b/Interface/PartialComponent.mo
@@ -1,4 +1,4 @@
-within TestPackage.Component;
+within TestPackage.Interface;
 partial model PartialComponent
   "Interface for Test Components"
 

--- a/Interface/package.order
+++ b/Interface/package.order
@@ -1,0 +1,2 @@
+ExtendInterface
+PartialComponent

--- a/Template/Data.mo
+++ b/Template/Data.mo
@@ -7,8 +7,22 @@ package Data "Test Data Package"
 
     parameter String record_parameter="Record Parameter"
     annotation (Evaluate=true, Dialog(group="Configuration"));
-  
+
     final parameter Boolean nested_bool=true;
+
+    /*
+  Test propagating UP a configuration parameter from a subcomponent
+  (inner/outer declarations are not allowed in records so an explicit parameter binding is needed
+  i.e. we cannot access selectable_component.container as in TestPackage.Component.ThirdComponent)
+  */
+    parameter TestPackage.Types.Container container_selectable_component
+      "Container Type"
+      annotation (Evaluate=true, Dialog(group="Configuration"));
+
+    parameter Boolean flag_enabled(start=true)
+      "Uninitialized parameter with enable attribute and start value"
+      annotation(Dialog(
+        enable=container_selectable_component==TestPackage.Types.Container.Bowl));
   end TestRecord;
 
 end Data;

--- a/Template/TestTemplate.mo
+++ b/Template/TestTemplate.mo
@@ -4,15 +4,13 @@ model TestTemplate "Test Template"
     Test that extends work as expected
   */
   extends TestPackage.Interface.ExtendInterface(
-    interface_param="Updated Value"
-  );
+    interface_param="Updated Value");
 
   /*
     Test that a subcomponent's options are added
   */
   TestPackage.Component.FirstComponent first(
-    component_param="First Component Template Override"
-  );
+    component_param="First Component Template Override");
 
   /*
     Test a replacable
@@ -20,28 +18,29 @@ model TestTemplate "Test Template"
   inner replaceable
     TestPackage.Component.SecondComponent
     selectable_component constrainedby
-    TestPackage.Interface.Partial(
-      final container=TestPackage.Types.Container.Cone
-    )
+    TestPackage.Interface.PartialComponent(
+      final container=TestPackage.Types.Container.Cone)
     "Replaceable Component"
     annotation (
       choices(
         choice(
           redeclare TestPackage.Component.SecondComponent selectable_component
-          "Second Test Component"
-        ),
+          "Second Test Component"),
         choice(
           redeclare TestPackage.Component.ThirdComponent selectable_component
-          "Third Test Component"
-        )
-      ),
-      Dialog(group="Selectable Component")
-    );
+          "Third Test Component")),
+      Dialog(group="Selectable Component"));
+
+  /*
+  Test that a subcomponent has access to an outer declaration
+  */
+  TestPackage.Component.ThirdComponent third_component;
 
   /*
     Test Record
   */
-  parameter TestPackage.Template.Data.TestRecord dat
+  parameter TestPackage.Template.Data.TestRecord dat(
+    final container_selectable_component=selectable_component.container)
     "Record with additional parameters";
 
   /*

--- a/Template/package.order
+++ b/Template/package.order
@@ -1,0 +1,2 @@
+Data
+TestTemplate

--- a/Types.mo
+++ b/Types.mo
@@ -11,11 +11,11 @@ package Types "Package with type definitions"
     "Enumeration for ice cream types";
 
   type Container = enumeration(
-    Hand
+      Hand
     "Hand",
-    Bowl
+      Bowl
     "Bowl",
-    Cone
+      Cone
     "Cone")
     "Enumeration for container types";
 

--- a/Validation/TestTemplateSecondComponent.mo
+++ b/Validation/TestTemplateSecondComponent.mo
@@ -1,0 +1,7 @@
+within TestPackage.Validation;
+model TestTemplateSecondComponent
+  "Validation model for TestTemplate with SecondComponent type for selectable_component"
+
+  Template.TestTemplate testTemplate(test_string_uninitialized="Initialize string")
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+end TestTemplateSecondComponent;

--- a/Validation/TestTemplateThirdComponent.mo
+++ b/Validation/TestTemplateThirdComponent.mo
@@ -1,0 +1,10 @@
+within TestPackage.Validation;
+model TestTemplateThirdComponent
+  "Validation model for with ThirdComponent type for selectable_component"
+
+  Template.TestTemplate testTemplate(redeclare
+      TestPackage.Component.ThirdComponent selectable_component
+      "Third Test Component",
+      test_string_uninitialized="Initialize string")
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+end TestTemplateThirdComponent;

--- a/Validation/package.mo
+++ b/Validation/package.mo
@@ -1,0 +1,4 @@
+within TestPackage;
+package Validation "Package with simulation models for validation"
+
+end Validation;

--- a/Validation/package.order
+++ b/Validation/package.order
@@ -1,0 +1,2 @@
+TestTemplateSecondComponent
+TestTemplateThirdComponent

--- a/package.order
+++ b/package.order
@@ -1,0 +1,5 @@
+Component
+Interface
+Template
+Types
+Validation


### PR DESCRIPTION
This PR 

- includes fixes for compliance with the Modelica specification,
- adds validation models than can be simulated (with parameter assignment and component redeclaration),
- adds an `outer` declaration to test that a subcomponent can access another subcomponent by reference,
- adds propagation of a configuration parameter within the data record and a parameter declaration with no assignment, a start value and a `Dialog(enable=...)` annotation. 